### PR TITLE
Fix marketplace.json source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "hoge",
-      "source": "../.claude",
+      "source": "./.claude",
       "description": "hogeと返すシンプルなコマンド",
       "version": "1.0.0"
     }


### PR DESCRIPTION
## Summary
- Fix source path from `../. claude` to `./.claude`
- Resolves schema validation error (source must start with `./`)

## Test plan
- [ ] Run `/plugin marketplace add s4na/cc-plugins`
- [ ] Run `/plugin install hoge@cc-plugins`
- [ ] Verify no schema validation errors

Generated with Claude Code