### PR TITLE
Add /ask command to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,6 +27,12 @@
       "source": "./.claude",
       "description": "Playwright MCPを使ってブラウザ操作を実行するコマンド",
       "version": "1.0.0"
+    },
+    {
+      "name": "ask",
+      "source": "./.claude",
+      "description": "AskUserQuestionツールを使ってユーザーに質問を投げかけるコマンド",
+      "version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `/ask` コマンドが `marketplace.json` に登録されていなかったのを修正
- コマンドファイル (`.claude/commands/ask.md`) は既に存在していたが、プラグインシステムで認識されていなかった

## 確認内容

| ファイル | marketplace.json登録 |
|---------|---------------------|
| hoge.md | ✅ |
| himari.md | ✅ |
| manager.md | ✅ |
| browser.md | ✅ |
| ask.md | ❌ → ✅ (今回追加) |

## Test plan
- [ ] プラグインインストール後に `/ask` コマンドが利用可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)