### PR TITLE
fix: /browserコマンドにMCP未インストール時の早期リターンを追加

### DIFF
--- a/.claude-basic/commands/browser.md
+++ b/.claude-basic/commands/browser.md
@@ -1,5 +1,23 @@
 あなたはブラウザ操作のコーディネーターです。自分では直接ブラウザ操作を行わず、browser-operator サブエージェントに作業を委譲します。
 
+## 前提条件チェック（最初に必ず実行）
+
+このコマンドは Chrome DevTools MCP が必要です。以下のツールが利用可能か確認してください：
+- `mcp__chrome_devtools__navigate_page`
+
+**ツールが利用できない場合は、以下のメッセージを表示して処理を終了してください：**
+
+```
+Chrome DevTools MCP がインストールされていません。
+
+以下のコマンドでインストールしてください：
+claude mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
+```
+
+**ツールが利用可能な場合のみ、以下の処理を続行してください。**
+
+---
+
 ## あなたの役割
 
 ユーザーからの依頼「$ARGUMENTS」を受けて、browser-operator サブエージェントにブラウザ操作を委譲してください。
@@ -174,7 +192,6 @@ Task ツールを使って browser-operator サブエージェントに作業を
 
 ## 注意事項
 
-- Chrome DevTools MCPが利用可能であることが前提（`claude mcp add chrome-devtools npx chrome-devtools-mcp@latest`）
 - 認証情報など機密データの取り扱いに注意
 - 長時間のスクレイピングは適切に分割して実行
 - サイトの利用規約を考慮するようユーザーに促す

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "basic",
       "source": "./.claude-basic",
       "description": "基本的なコマンド集（himari, manager, browser, ask）とサブエージェント",
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `/browser` コマンド実行時に Chrome DevTools MCP が利用可能かチェック
- MCPがインストールされていない場合、インストール方法を表示して早期リターン
- basic プラグインのバージョンを 1.0.1 → 1.0.2 に更新

## Test plan
- [ ] Chrome DevTools MCP がインストールされていない状態で `/browser` を実行し、エラーメッセージが表示されることを確認
- [ ] Chrome DevTools MCP がインストールされている状態で `/browser` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)