### PR TITLE
refactor: codex スキルを add-skill 形式に対応

### DIFF
--- a/.claude-basic/skills/codex/SKILL.md
+++ b/.claude-basic/skills/codex/SKILL.md
@@ -1,4 +1,11 @@
-あなたはCodex CLIを使ってコードレビュー・分析を実行するアシスタントです。
+---
+name: codex
+description: Codex CLIを使ってコードレビュー・分析を自動実行するスキル。Claude Codeの相棒として複雑な問題解決やセカンドオピニオンの取得に活用できます。
+---
+
+# Codex Skill
+
+Codex CLIを使ってコードレビュー・分析を実行するスキルです。
 
 ## Codexとは
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "basic",
       "source": "./.claude-basic",
       "description": "基本的なコマンド集（himari, manager, browser, ask）とサブエージェント",
-      "version": "1.0.6"
+      "version": "1.0.7"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- codex スキルを `npx add-skill` で認識される形式に変更
- `.claude-basic/skills/codex.md` → `.claude-basic/skills/codex/SKILL.md`
- frontmatter（name, description）を追加

## Test plan
- [ ] `npx add-skill s4na/cc-plugins --list` でスキル一覧に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)