### PR TITLE
docs: CLAUDE.md にスキル作成ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,60 @@
   "version": "1.0.1"  // 変更後
 }
 ```
+
+## スキル作成ルール
+
+スキルを作成する場合は、`npx add-skill` に対応する形式で作成してください。
+
+### ディレクトリ構造
+```
+.claude-basic/skills/
+  <スキル名>/
+    SKILL.md    ← 必須
+```
+
+### SKILL.md の形式
+ファイル名は必ず `SKILL.md`（大文字）にしてください。
+
+```markdown
+---
+name: <スキル名>
+description: <スキルの説明>
+---
+
+# <スキル名>
+
+<スキルの詳細な説明と使い方>
+```
+
+### 必須要素
+- **frontmatter**: `---` で囲んだ YAML 形式のメタデータ
+  - `name`: スキルの識別子（小文字、ハイフン使用可）
+  - `description`: スキルの簡潔な説明
+- **本文**: スキルの詳細な説明、使い方、実行手順など
+
+### 例
+`codex` スキルの場合:
+```
+.claude-basic/skills/
+  codex/
+    SKILL.md
+```
+
+```markdown
+---
+name: codex
+description: Codex CLIを使ってコードレビュー・分析を自動実行するスキル
+---
+
+# Codex Skill
+
+Codex CLIを使ってコードレビュー・分析を実行するスキルです。
+...
+```
+
+### 確認方法
+スキル作成後、以下のコマンドで認識されることを確認してください:
+```bash
+npx add-skill s4na/cc-plugins --list
+```


### PR DESCRIPTION
## Summary
- スキル作成時の `add-skill` 対応形式をドキュメント化
- ディレクトリ構造、SKILL.md の必須形式、確認方法を記載

## Test plan
- [ ] CLAUDE.md の内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)