### PR TITLE
feat: ask コマンドをスキルに変換

### DIFF
--- a/.claude-basic/skills/ask/SKILL.md
+++ b/.claude-basic/skills/ask/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: ask
+description: ユーザーに質問を投げかけるアシスタント。AskUserQuestionツールを使って選択肢付きの質問を提示します。
+---
+
+# Ask Skill
+
 あなたはユーザーに質問を投げかけるアシスタントです。
 
 ユーザーからの指示「$ARGUMENTS」に基づいて、AskUserQuestion ツールを使ってユーザーに質問してください。
@@ -125,7 +132,7 @@
 
 ## 参考情報
 
-このコマンドは以下のベストプラクティスに基づいています：
+このスキルは以下のベストプラクティスに基づいています：
 
 - [Claude Code: Best practices for agentic coding](https://www.anthropic.com/engineering/claude-code-best-practices)
 - [Efficient Vibe Coding: How Clarifying Questions Make AI Actually Useful](https://www.dandoescode.com/blog/efficient-vibe-coding-with-clarifying-questions)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "basic",
       "source": "./.claude-basic",
       "description": "基本的なコマンド集（himari, manager, browser, ask）とサブエージェント",
-      "version": "1.0.7"
+      "version": "1.0.8"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `.claude-basic/commands/ask.md` をスキル形式に変換
- `npx add-skill` に対応した frontmatter を追加
- basic プラグインのバージョンを 1.0.8 にインクリメント

## Test plan
- [ ] `npx add-skill s4na/cc-plugins --list` で ask スキルが認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)