### PR TITLE
docs: add-skillの記述を削除しマーケットプレイス経由を推奨

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,7 @@ Claude Code用のカスタムスラッシュコマンド集です。
 
 ## インストール方法
 
-### npx add-skill を使用（推奨）
-
-[add-skill](https://github.com/vercel-labs/add-skill) を使って簡単にインストールできます。
-
-スキル一覧を確認:
-```bash
-npx add-skill s4na/cc-plugins --list
-```
-
-全てのスキルをインストール:
-```bash
-npx add-skill s4na/cc-plugins
-```
-
-特定のスキルのみインストール:
-```bash
-npx add-skill s4na/cc-plugins --skill basic
-```
-```bash
-npx add-skill s4na/cc-plugins --skill hoge
-```
-
-グローバルインストール（ユーザーディレクトリ）:
-```bash
-npx add-skill s4na/cc-plugins -g
-```
-
-### マーケットプレイス経由
+### マーケットプレイス経由（推奨）
 
 Claude Codeで以下のコマンドを実行してマーケットプレイスを追加します：
 


### PR DESCRIPTION
## Summary
- READMEからnpx add-skillによるインストール方法の記述を削除
- Claude公式のプラグイン方式（マーケットプレイス経由）を推奨として統一

## Test plan
- [ ] READMEの内容が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)